### PR TITLE
[feat][#4] UIKit 컴포넌트 live preview 만들기

### DIFF
--- a/Targets/Mashow/Sources/MashowRootViewController.swift
+++ b/Targets/Mashow/Sources/MashowRootViewController.swift
@@ -11,6 +11,21 @@ import UIKit
 class MashowRootViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .systemBackground
+        view.backgroundColor = .systemBlue
+    }
+}
+
+import SwiftUI
+#Preview {
+    VStack {
+        MashowRootViewController.preview()
+        
+        // or
+        MashowRootViewController.preview {
+            let vc = MashowRootViewController()
+            
+            vc.view.backgroundColor = .red
+            return vc
+        }
     }
 }

--- a/Targets/Mashow/Sources/Util/UIView+Preview.swift
+++ b/Targets/Mashow/Sources/Util/UIView+Preview.swift
@@ -1,0 +1,60 @@
+//
+//  UIView+Preview.swift
+//  Mashow
+//
+//  Created by Kai Lee on 7/18/24.
+//  Copyright © 2024 com.alcoholers. All rights reserved.
+//
+
+import SwiftUI
+
+/// A `UIViewControllerRepresentable` SwiftUI `View` that wraps its `Content`
+struct SwiftUIView<Content: UIView> {
+    /// A closure that's invoked to construct the represented content view.
+    var makeContent: () -> Content
+    
+    /// Creates a SwiftUI representation of the content view with the provided `makeContent` closure
+    /// to construct it whenever `makeUIViewController(…)` is invoked.
+    init(makeContent: @escaping () -> Content) {
+        self.makeContent = makeContent
+    }
+}
+
+// MARK: - UIViewRepresentable
+extension SwiftUIView: UIViewRepresentable {
+    func makeUIView(context: Context) -> Content {
+        makeContent()
+    }
+    
+    func updateUIView(_ uiView: Content, context: Context) {}
+}
+
+// MARK: - ViewType
+/// A protocol that all `UIView`s conform to, enabling extensions that have a `Self` reference.
+protocol ViewType: UIView {}
+
+// MARK: - ViewType + ViewTypeProtocol
+extension UIView: ViewType {}
+
+// MARK: - ViewTypeProtocol + preview
+extension ViewType {
+    /// 주어진 `makeView` 클로저를 이용해 `UIView`를 나타내는 SwiftUI `View`를 반환합니다.
+    ///
+    /// ```
+    /// MyUIView.preview {
+    ///    return MyUIView()
+    /// }
+    /// ```
+    static func preview(makeView: @escaping () -> Self) -> SwiftUIView<Self> {
+        SwiftUIView(makeContent: makeView)
+    }
+    
+    /// 초기화된 `UIView`를 기본 생성자로 생성하여 SwiftUI `View`를 반환합니다.
+    ///
+    /// `MyUIView.preview()`
+    static func preview() -> SwiftUIView<Self> {
+        let defaultMakeView = { Self.init() }
+        return preview(makeView: defaultMakeView)
+    }
+}
+

--- a/Targets/Mashow/Sources/Util/UIViewController+Preview.swift
+++ b/Targets/Mashow/Sources/Util/UIViewController+Preview.swift
@@ -1,0 +1,59 @@
+//
+//  Preview.swift
+//  MashowKit
+//
+//  Created by Kai Lee on 7/18/24.
+//  Copyright © 2024 com.alcoholers. All rights reserved.
+//
+
+import SwiftUI
+
+/// A `UIViewControllerRepresentable` SwiftUI `View` that wraps its `Content`
+struct SwiftUIViewController<Content: UIViewController> {
+    /// A closure that's invoked to construct the represented content view.
+    var makeContent: () -> Content
+    
+    /// Creates a SwiftUI representation of the content view with the provided `makeContent` closure
+    /// to construct it whenever `makeUIViewController(…)` is invoked.
+    init(makeContent: @escaping () -> Content) {
+        self.makeContent = makeContent
+    }
+}
+
+// MARK: - UIViewControllerRepresentable
+extension SwiftUIViewController: UIViewControllerRepresentable {
+    func makeUIViewController(context: Context) -> Content {
+        makeContent()
+    }
+    
+    func updateUIViewController(_ viewController: Content, context: Context) {}
+}
+
+// MARK: - ViewControllerType
+/// A protocol that all `UIViewController`s conform to, enabling extensions that have a `Self` reference.
+protocol ViewControllerType: UIViewController {}
+
+// MARK: - ViewType + ViewTypeProtocol
+extension UIViewController: ViewControllerType {}
+
+// MARK: - ViewControllerTypeProtocol + preview
+extension ViewControllerType {
+    /// 주어진 `makeView` 클로저를 이용해 `UIViewController`를 나타내는 SwiftUI `View`를 반환합니다.
+    ///
+    /// ```
+    /// MyUIViewController.preview {
+    ///    return MyUIViewController()
+    /// }
+    /// ```
+    static func preview(makeView: @escaping () -> Self) -> SwiftUIViewController<Self> {
+        SwiftUIViewController(makeContent: makeView)
+    }
+    
+    /// 초기화된 `UIViewController`를 기본 생성자로 생성하여 SwiftUI `View`를 반환합니다.
+    ///
+    /// `MyUIViewController.preview()`
+    static func preview() -> SwiftUIViewController<Self> {
+        let defaultMakeView = { Self.init() }
+        return preview(makeView: defaultMakeView)
+    }
+}


### PR DESCRIPTION
### Summary
이거 쓰시면 UIKit에서도 편하게 live-preview 할 수 있읍니다. 안 써도 상관 없는데 만들어두면 머 도움은 되니까... (난 쓸 거임)

### Usage
``` Swift
// For VC
#Preview {
    VStack {
        MashowRootViewController.preview()
        
        // or
        MashowRootViewController.preview {
            let vc = MashowRootViewController()
            
            vc.view.backgroundColor = .red
            return vc
        }
    }
}

// For View
#Preview {
    VStack {
        MashowRootView.preview()
        
        // or
        MashowRootView.preview {
            let view = MashowRootView()
            
            view.backgroundColor = .red
            return view
        }
    }
}
```
### Result
<img width="945" alt="image" src="https://github.com/user-attachments/assets/aef8dab2-89b4-4a2f-90b2-fbc0a4fe0f98">
