### PR TITLE
[feat][#7] 카카오 로그인 & `AuthManager` & `Storage` & `XCConfig` etc.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ Derived/
 ### Tuist managed dependencies ###
 Tuist/Dependencies
 master.key
+*.xcconfig

--- a/Targets/Mashow/Sources/Application/AppDelegate.swift
+++ b/Targets/Mashow/Sources/Application/AppDelegate.swift
@@ -9,13 +9,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil
     ) -> Bool {
-        if
-            let kakaoAppKey = Bundle.main.object(forInfoDictionaryKey: "KAKAO_APP_KEY") as? String,
-            let baseUrl = Bundle.main.object(forInfoDictionaryKey: "BASE_API_URL") as? String
-        {
-            KakaoSDK.initSDK(appKey: kakaoAppKey)
+        guard let kakaoAppKey = Bundle.main.object(forInfoDictionaryKey: "KAKAO_APP_KEY") as? String else {
+            fatalError("XCConfig을 잘못 넣으셨군요...")
         }
         
+        KakaoSDK.initSDK(appKey: kakaoAppKey)
         return true
     }
 

--- a/Targets/Mashow/Sources/Application/AppDelegate.swift
+++ b/Targets/Mashow/Sources/Application/AppDelegate.swift
@@ -1,6 +1,7 @@
 import UIKit
 
-import Kingfisher
+import KakaoSDKCommon
+import KakaoSDKAuth
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -8,7 +9,21 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil
     ) -> Bool {
-
+        if
+            let kakaoAppKey = Bundle.main.object(forInfoDictionaryKey: "KAKAO_APP_KEY") as? String,
+            let baseUrl = Bundle.main.object(forInfoDictionaryKey: "BASE_API_URL") as? String
+        {
+            KakaoSDK.initSDK(appKey: kakaoAppKey)
+        }
+        
         return true
+    }
+
+    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+        if (AuthApi.isKakaoTalkLoginUrl(url)) {
+            return AuthController.handleOpenUrl(url: url)
+        }
+
+        return false
     }
 }

--- a/Targets/Mashow/Sources/Util/Environment.swift
+++ b/Targets/Mashow/Sources/Util/Environment.swift
@@ -14,4 +14,9 @@ struct Environment {
     static var network: NetworkManager<API> {
         internalNetwork
     }
+    
+    private static let internalStorage = StorageManager()
+    static var storage: StorageManager {
+        internalStorage
+    }
 }

--- a/Targets/Mashow/Sources/Util/Login/AuthorizationManager+Apple.swift
+++ b/Targets/Mashow/Sources/Util/Login/AuthorizationManager+Apple.swift
@@ -1,0 +1,9 @@
+//
+//  AuthorizationManager+Apple.swift
+//  MashowTests
+//
+//  Created by Kai Lee on 7/25/24.
+//  Copyright © 2024 com.alcoholers. All rights reserved.
+//
+
+import Foundation

--- a/Targets/Mashow/Sources/Util/Login/AuthorizationManager+Apple.swift
+++ b/Targets/Mashow/Sources/Util/Login/AuthorizationManager+Apple.swift
@@ -7,3 +7,10 @@
 //
 
 import Foundation
+
+extension AuthorizationManager {
+    // FIXME: 잘 고쳐줘 다연아
+    func signInWithApple() async throws -> (idToken: String, accessToken: String) {
+        fatalError()
+    }
+}

--- a/Targets/Mashow/Sources/Util/Login/AuthorizationManager+Kakao.swift
+++ b/Targets/Mashow/Sources/Util/Login/AuthorizationManager+Kakao.swift
@@ -11,6 +11,7 @@ import KakaoSDKAuth
 import KakaoSDKUser
 
 extension AuthorizationManager {
+    /// 카카오 로그인 요청 후 카카오 액세스 토큰을 반환한다
     func signInWithKakao() async throws -> String {
         try await withCheckedThrowingContinuation { continuation in
             // 카카오톡 앱 사용 가능 여부 확인

--- a/Targets/Mashow/Sources/Util/Login/AuthorizationManager+Kakao.swift
+++ b/Targets/Mashow/Sources/Util/Login/AuthorizationManager+Kakao.swift
@@ -1,0 +1,48 @@
+//
+//  AuthorizationManager+Kakao.swift
+//  Mashow
+//
+//  Created by Kai Lee on 7/24/24.
+//  Copyright © 2024 com.alcoholers. All rights reserved.
+//
+
+import Foundation
+import KakaoSDKAuth
+import KakaoSDKUser
+
+extension AuthorizationManager {
+    func signInWithKakao() async throws -> String {
+        try await withCheckedThrowingContinuation { continuation in
+            // 카카오톡 앱 사용 가능 여부 확인
+            if UserApi.isKakaoTalkLoginAvailable() {
+                // 앱 있으면 앱으로
+                UserApi.shared.loginWithKakaoTalk { (oauthToken, error) in
+                    if let error {
+                        continuation.resume(throwing: error)
+                    } else {
+                        guard let token = oauthToken?.accessToken else {
+                            continuation.resume(throwing: URLError(.badServerResponse))
+                            return
+                        }
+                        
+                        continuation.resume(returning: token)
+                    }
+                }
+            } else {
+                // 앱 없으면 웹으로
+                UserApi.shared.loginWithKakaoAccount { (oauthToken, error) in
+                    if let error {
+                        continuation.resume(throwing: error)
+                    } else {
+                        guard let token = oauthToken?.accessToken else {
+                            continuation.resume(throwing: URLError(.badServerResponse))
+                            return
+                        }
+                        
+                        continuation.resume(returning: token)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Targets/Mashow/Sources/Util/Login/AuthorizationManager.swift
+++ b/Targets/Mashow/Sources/Util/Login/AuthorizationManager.swift
@@ -8,26 +8,12 @@
 
 import Foundation
 
-final class AuthorizationManager {
+struct AuthorizationManager {
     private let networkManager: NetworkManager<API>
-    private let storageManager: StorageManager
-    
-    /// 로그인 여부 판별 등에 사용되는 permanent 액세스 토큰.
-    /// 내부에서 로그인 성공/로그아웃 시 자체적으로 업데이트 된다.
-    private(set) var accessToken: String? {
-        get {
-            storageManager.accessToken
-        }
-        set {
-            storageManager.accessToken = newValue
-        }
-    }
     
     init(
-        _ storageManager: StorageManager = Environment.storage,
         _ networkManager: NetworkManager<API> = Environment.network
     ) {
-        self.storageManager = storageManager
         self.networkManager = networkManager
     }
     
@@ -46,12 +32,7 @@ final class AuthorizationManager {
             mashowAccessToken = try await networkManager.request(.testPost(id: 123), of: String.self)
         }
         
-        self.accessToken = mashowAccessToken
         return mashowAccessToken
-    }
-    
-    func signOut() {
-        accessToken = nil
     }
 }
 

--- a/Targets/Mashow/Sources/Util/Login/AuthorizationManager.swift
+++ b/Targets/Mashow/Sources/Util/Login/AuthorizationManager.swift
@@ -1,0 +1,9 @@
+//
+//  KakaoLoginManager.swift
+//  MashowTests
+//
+//  Created by Kai Lee on 7/24/24.
+//  Copyright © 2024 com.alcoholers. All rights reserved.
+//
+
+import Foundation

--- a/Targets/Mashow/Sources/Util/Login/AuthorizationManager.swift
+++ b/Targets/Mashow/Sources/Util/Login/AuthorizationManager.swift
@@ -1,5 +1,5 @@
 //
-//  KakaoLoginManager.swift
+//  AuthorizationManager.swift
 //  MashowTests
 //
 //  Created by Kai Lee on 7/24/24.
@@ -7,3 +7,57 @@
 //
 
 import Foundation
+
+final class AuthorizationManager {
+    private let networkManager: NetworkManager<API>
+    private let storageManager: StorageManager
+    
+    /// 로그인 여부 판별 등에 사용되는 permanent 액세스 토큰.
+    /// 내부에서 로그인 성공/로그아웃 시 자체적으로 업데이트 된다.
+    private(set) var accessToken: String? {
+        get {
+            storageManager.accessToken
+        }
+        set {
+            storageManager.accessToken = newValue
+        }
+    }
+    
+    init(
+        _ storageManager: StorageManager = Environment.storage,
+        _ networkManager: NetworkManager<API> = Environment.network
+    ) {
+        self.storageManager = storageManager
+        self.networkManager = networkManager
+    }
+    
+    /// Platform 별로 로그인 요청 후 성공하면 서버에 액세스 토큰을 요청함.
+    /// - Returns: 성공 시 액세스 토큰을 반환함.
+    func signIn(with platform: PlatformType) async throws -> String {
+        let mashowAccessToken: String
+        
+        switch platform {
+        case .apple:
+            // FIXME: 잘 고쳐줘 다연아
+            fatalError()
+        case .kakao:
+            // FIXME: API 나오면 아래 부분 수정
+            let accessToken = try await signInWithKakao()
+            mashowAccessToken = try await networkManager.request(.testPost(id: 123), of: String.self)
+        }
+        
+        self.accessToken = mashowAccessToken
+        return mashowAccessToken
+    }
+    
+    func signOut() {
+        accessToken = nil
+    }
+}
+
+extension AuthorizationManager {
+    enum PlatformType {
+        case apple
+        case kakao
+    }
+}

--- a/Targets/Mashow/Sources/Util/Network/API.swift
+++ b/Targets/Mashow/Sources/Util/Network/API.swift
@@ -53,11 +53,6 @@ extension API: TargetType {
     
     var headers: [String : String]? {
         var header = ["Content-type": "application/json"]
-        // Add authorization headers if exists
-        if let accessToken = Environment.network.accessToken {
-             header["Authorization"] = "Bearer \(accessToken)"
-         }
-        
         return header
     }
     

--- a/Targets/Mashow/Sources/Util/Network/API.swift
+++ b/Targets/Mashow/Sources/Util/Network/API.swift
@@ -17,7 +17,11 @@ enum API {
 
 extension API: TargetType {
     var baseURL: URL {
-        return URL(string: "https://api.example.com")!
+        guard let baseUrl = Bundle.main.object(forInfoDictionaryKey: "BASE_API_URL") as? String else {
+            fatalError("XCConfig을 잘못 넣으셨군요...")
+        }
+        
+        return URL(string: baseUrl)!
     }
     
     var path: String {

--- a/Targets/Mashow/Sources/Util/Network/NetworkManager.swift
+++ b/Targets/Mashow/Sources/Util/Network/NetworkManager.swift
@@ -6,30 +6,80 @@
 //  Copyright © 2024 com.alcoholers. All rights reserved.
 //
 
-import Moya
 import Foundation
+import Moya
 
 final class NetworkManager<Target> where Target: TargetType {
+    private(set) var provider: MoyaProvider<Target>
+    private let lock = NSLock()
+    private var plugins: [PluginType] = []
+    
     init(provider: MoyaProvider<Target> = MoyaProvider<Target>()) {
         self.provider = provider
+        self.plugins = provider.plugins
     }
     
-    private let provider: MoyaProvider<Target>
-    private(set) var accessToken: String?
-    
-    // MARK: - Manage access token
-    func registerAccessToken(token: String) {
-        accessToken = token
+    // MARK: Manage access token
+    func registerAccessToken(accessToken: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        
+        updateProvider(with: BearerTokenPlugin(accessToken: accessToken))
     }
     
     func removeAccessToken() {
-        accessToken = nil
+        lock.lock()
+        defer { lock.unlock() }
+        
+        updateProvider(removeBearerToken: true)
     }
     
-    // MARK: - API Request
+    // MARK: API Request
     func request<T>(_ api: Target, of type: T.Type) async throws -> T where T: Decodable {
         try await provider
             .request(api)
             .map(T.self)
+    }
+}
+
+// MARK: - Private
+private extension NetworkManager {
+    func updateProvider(with newPlugin: PluginType? = nil, removeBearerToken: Bool = false) {
+        plugins = plugins.withoutBearerTokenPlugins
+        
+        if let newPlugin = newPlugin {
+            plugins.append(newPlugin)
+        }
+        
+        provider = MoyaProvider<Target>(
+            endpointClosure: provider.endpointClosure,
+            requestClosure: provider.requestClosure,
+            stubClosure: provider.stubClosure,
+            session: provider.session,
+            plugins: plugins,
+            trackInflights: provider.trackInflights
+        )
+    }
+}
+
+// MARK: - Token Plugin
+final class BearerTokenPlugin: PluginType {
+    private let accessToken: String
+    
+    init(accessToken: String) {
+        self.accessToken = accessToken
+    }
+    
+    /// Add Authorization Header
+    func prepare(_ request: URLRequest, target: TargetType) -> URLRequest {
+        var request = request
+        request.addValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        return request
+    }
+}
+
+private extension [PluginType] {
+    var withoutBearerTokenPlugins: [PluginType] {
+        filter { !($0 is BearerTokenPlugin) }
     }
 }

--- a/Targets/Mashow/Sources/Util/Storage/StorageManager.swift
+++ b/Targets/Mashow/Sources/Util/Storage/StorageManager.swift
@@ -1,0 +1,36 @@
+//
+//  StorageManager.swift
+//  MashowTests
+//
+//  Created by Kai Lee on 7/25/24.
+//  Copyright © 2024 com.alcoholers. All rights reserved.
+//
+
+import Foundation
+
+final class StorageManager {
+    private let userDefaults: UserDefaults
+    
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+    }
+}
+
+// MARK: - 프로퍼티들
+extension StorageManager {
+    var accessToken: String? {
+        get {
+            userDefaults.string(forKey: StorageKey.accessToken.rawValue)
+        }
+        set {
+            userDefaults.set(newValue, forKey: StorageKey.accessToken.rawValue)
+        }
+    }
+}
+
+// MARK: - Private
+private extension StorageManager {
+    enum StorageKey: String {
+        case accessToken
+    }
+}

--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -18,7 +18,9 @@ let dependencies = Dependencies(
         // Kingfisher
         .remote(url: "https://github.com/onevcat/Kingfisher.git", requirement: .upToNextMajor(from: "7.0.0")),
         // Lottie
-        .remote(url: "https://github.com/airbnb/lottie-ios.git", requirement: .upToNextMajor(from: "3.4.3"))
+        .remote(url: "https://github.com/airbnb/lottie-ios.git", requirement: .upToNextMajor(from: "3.4.3")),
+        // Kakao
+        .remote(url: "https://github.com/kakao/kakao-ios-sdk.git", requirement: .upToNextMajor(from: "2.22.5"))
     ],
     platforms: [.iOS]
 )

--- a/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -36,7 +36,9 @@ extension Project {
                                 .external(name: "SnapKit"),
                                 .external(name: "Moya"),
                                 .external(name: "Kingfisher"),
-                                .external(name: "Lottie")
+                                .external(name: "Lottie"),
+                                .external(name: "KakaoSDKAuth"),
+                                .external(name: "KakaoSDKUser")
                              ])
         let tests = Target(name: "\(name)Tests",
                            platform: platform,

--- a/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -40,6 +40,7 @@ extension Project {
                                 .external(name: "KakaoSDKAuth"),
                                 .external(name: "KakaoSDKUser")
                              ])
+        
         let tests = Target(name: "\(name)Tests",
                            platform: platform,
                            product: .unitTests,
@@ -49,6 +50,7 @@ extension Project {
                            sources: ["Targets/\(name)/Tests/**"],
                            resources: [],
                            dependencies: [.target(name: name)])
+        
         return [sources, tests]
     }
     
@@ -67,10 +69,39 @@ extension Project {
                             "UISceneDelegateClassName": "$(PRODUCT_MODULE_NAME).SceneDelegate"
                         ],
                     ]
-                ]
+                ],
             ],
+            "LSApplicationQueriesSchemes": ["kakaokompassauth", "kakaolink", "kakaoplus", "kakaotalk"],
+            "NSAppTransportSecurity": [
+                "NSAllowsArbitraryLoads": true
+            ],
+            "CFBundleURLTypes": [
+                [
+                    "CFBundleTypeRole": "Editor",
+                    "CFBundleURLSchemes": [
+                        "$(KAKAO_APP_KEY)://oauth"
+                    ]
+                ],
+                [
+                    "CFBundleTypeRole": "Editor",
+                    "CFBundleURLSchemes": [
+                        "$(KAKAO_APP_KEY)://kakaolink"
+                    ]
+                ],
+            ],
+            "KAKAO_APP_KEY": "$(KAKAO_APP_KEY)",
+            "BASE_API_URL": "$(BASE_API_URL)"
         ]
         
+        let debugConfiguration = Configuration.debug(
+            name: .debug,
+            xcconfig: .relativeToRoot("Configurations/Debug.xcconfig"))
+        
+        let releaseConfiguration = Configuration.release(
+            name: .release,
+            xcconfig: .relativeToRoot("Configurations/Release.xcconfig")
+        )
+
         let mainTarget = Target(
             name: name,
             platform: platform,
@@ -80,7 +111,11 @@ extension Project {
             infoPlist: .extendingDefault(with: infoPlist),
             sources: ["Targets/\(name)/Sources/**"],
             resources: ["Targets/\(name)/Resources/**"],
-            dependencies: dependencies
+            dependencies: dependencies,
+            settings: .settings(configurations: [
+               debugConfiguration,
+               releaseConfiguration
+            ])
         )
         
         let testTarget = Target(


### PR DESCRIPTION
### 바뀐 것
1. `AuthorizationManager`와 `Environment.storage` 추가
2. Kakao 로그인 추가
3. App Key 보호를 위해서 `xcconfig` 추가
4. It resolves #7 

## 참고
### 1. 디스코드 `xcconfig 공유 스레드`에 올려 놓은 3개 파일을 여기에 넣으세용
<img width="984" alt="image" src="https://github.com/user-attachments/assets/b28c720b-7016-4025-8c24-675e7f46a5e1">

- 안 넣으면 빌드 안되고 크래시 날 것임

### 2.  `AuthorizationManagaer`, `Environment.storage`, `Environment.network` 사용 상상도

``` Swift 
let accessToken: String
if let mashowToken = Environment.storage.accessToken {
    // 이미 로그인 -> 메인 페이지
    accessToken = mashowToken
} else {
    // 로그인 안 됨 -> 로그인 페이지 이동
    // 그 담에 로그인 시도
    accessToken = try await AuthorizationManager().signIn(with: .kakao)
}

Environment.storage.accessToken = accessToken
Environment.network.registerAccessToken(accessToken: accessToken)
```

### 리뷰 포인트
- 2번 사용 상상도에서 구조가 사용하기 너무 번거롭거나 복잡하지 않은지
  - storage를 auth 매니저 안에 넣을까 말까 하다가 둘 사이의 연관성이 상상이 잘 안가서 빼버리고 수동으로 추가하게 만들었음. 합치는게 나을까 아직 고민이긴 함. b29595c706e7cc9bac2eb1e4ce4bd2a3537946be 참고
- `AuthorizationManager` 내부구조도 너무 짜치면 말해주셈. Apple 로그인 구현할 떄는 나처럼 메서드 하나로 안 하고 클래스 따로 빼서 만들어도 됨..ㅋ
- 각종 네이밍 